### PR TITLE
Add missing xmlunicode.c and update readme to match artifact name

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Zig
-        uses: mlugg/setup-zig@v1
+        uses: mlugg/setup-zig@v2
         with:
           version: ${{ matrix.zig-version }}
 

--- a/README.md
+++ b/README.md
@@ -21,5 +21,5 @@ const libxml2_dependency = b.dependency("libxml2", .{
     .target = target,
     .optimize = optimize,
 });
-your_exe.linkLibrary(libxml2_dependency.artifact("libxml2"));
+your_exe.linkLibrary(libxml2_dependency.artifact("xml"));
 ```

--- a/build.zig
+++ b/build.zig
@@ -181,7 +181,7 @@ pub fn build(b: *std.Build) void {
     if (output) xml_lib.root_module.addCSourceFile(.{ .file = upstream.path("xmlsave.c"), .flags = xml_flags });
     if (pattern) xml_lib.root_module.addCSourceFile(.{ .file = upstream.path("pattern.c"), .flags = xml_flags });
     if (reader) xml_lib.root_module.addCSourceFile(.{ .file = upstream.path("xmlreader.c"), .flags = xml_flags });
-    if (regexps) xml_lib.root_module.addCSourceFiles(.{ .files = &.{"xmlregexp.c"}, .root = upstream.path(""), .flags = xml_flags });
+    if (regexps) xml_lib.root_module.addCSourceFiles(.{ .files = &.{ "xmlregexp.c", "xmlunicode.c" }, .root = upstream.path(""), .flags = xml_flags });
     if (relaxng) xml_lib.root_module.addCSourceFile(.{ .file = upstream.path("relaxng.c"), .flags = xml_flags });
     if (schemas) xml_lib.root_module.addCSourceFiles(.{ .files = &.{ "xmlschemas.c", "xmlschemastypes.c" }, .root = upstream.path(""), .flags = xml_flags });
     if (schematron) xml_lib.root_module.addCSourceFile(.{ .file = upstream.path("schematron.c"), .flags = xml_flags });


### PR DESCRIPTION
Added xmlunicode.c to resolve missing symbol errors during linking an executable. Also updated the README to reflect the correct artifact name: xml.