### PR TITLE
Update translate-c to work with zig 0.17.x/master

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,8 @@ jobs:
       fail-fast: false
       matrix:
         zig-version: [master]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,8 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         zig-version: [master]
-        # os: [ubuntu-latest, macos-latest, windows-latest]
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -23,8 +23,8 @@
             .lazy = true,
         },
         .translate_c = .{
-            .url = "git+https://codeberg.org/ziglang/translate-c#1b33d1d273f7035a16c45457efdf2afda7cf0925",
-            .hash = "translate_c-0.0.0-Q_BUWrI7BwCBn0jcYDTs1UP047kxSYoFpV6vD6Vuy9Vo",
+            .url = "git+https://codeberg.org/ziglang/translate-c#f94ce1b138c8ad04959de2fea01fc8981cc2ae77",
+            .hash = "translate_c-0.0.0-Q_BUWp84BwD-R_KrWywVjsMETfqkMv4iPdnBUx48FS6y",
         },
     },
     .paths = .{


### PR DESCRIPTION
Updating the translate-c dependency for libxml to work with zig 0.17.x/master projects (like microzig, where this currently breaks it).

See https://codeberg.org/ziglang/translate-c/commit/f94ce1b138c8ad04959de2fea01fc8981cc2ae77