### PR TITLE
chore: update translate-c

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -23,8 +23,8 @@
             .lazy = true,
         },
         .translate_c = .{
-            .url = "git+https://codeberg.org/ziglang/translate-c#1b33d1d273f7035a16c45457efdf2afda7cf0925",
-            .hash = "translate_c-0.0.0-Q_BUWrI7BwCBn0jcYDTs1UP047kxSYoFpV6vD6Vuy9Vo",
+            .url = "git+https://codeberg.org/ziglang/translate-c#2a6613bcc09c74296d785e660fe98d2eb310d760",
+            .hash = "translate_c-0.0.0-Q_BUWjQ7BwAhlMt3Zf4l3Jw-y0_TOpJWgcK8rk4d0aWv",
         },
     },
     .paths = .{


### PR DESCRIPTION
This work was already done 3 weeks ago in #8 but it had CI failures and didn't get merged so i thought it began to bitrot and made my own PR. This blocks [microzig's upgrade PR](https://github.com/ZigEmbeddedGroup/microzig/pull/996).